### PR TITLE
필터 옵션 최대 너비 스타일 개선

### DIFF
--- a/components/home/filter-sidebar.tsx
+++ b/components/home/filter-sidebar.tsx
@@ -100,27 +100,27 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
             setBudget(value as typeof budget);
             handleApplyFilters();
           }}>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 w-full">
               <RadioGroupItem value="전체" id="budget-all" />
-              <Label htmlFor="budget-all" className="font-normal cursor-pointer">
+              <Label htmlFor="budget-all" className="font-normal cursor-pointer flex-1">
                 전체
               </Label>
             </div>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 w-full">
               <RadioGroupItem value="100만원 이하" id="budget-under100" />
-              <Label htmlFor="budget-under100" className="font-normal cursor-pointer">
+              <Label htmlFor="budget-under100" className="font-normal cursor-pointer flex-1">
                 100만원 이하
               </Label>
             </div>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 w-full">
               <RadioGroupItem value="100~200만원" id="budget-100to200" />
-              <Label htmlFor="budget-100to200" className="font-normal cursor-pointer">
+              <Label htmlFor="budget-100to200" className="font-normal cursor-pointer flex-1">
                 100~200만원
               </Label>
             </div>
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-2 w-full">
               <RadioGroupItem value="200만원 이상" id="budget-over200" />
-              <Label htmlFor="budget-over200" className="font-normal cursor-pointer">
+              <Label htmlFor="budget-over200" className="font-normal cursor-pointer flex-1">
                 200만원 이상
               </Label>
             </div>
@@ -134,7 +134,7 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
           <Label>지역</Label>
           <div className="grid grid-cols-2 gap-2">
             {regions.map((region) => (
-              <div key={region} className="flex items-center space-x-2">
+              <div key={region} className="flex items-center space-x-2 w-full">
                 <Checkbox
                   id={`region-${region}`}
                   checked={selectedRegions.includes(region)}
@@ -145,7 +145,7 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
                 />
                 <label
                   htmlFor={`region-${region}`}
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1"
                 >
                   {region}
                 </label>
@@ -161,7 +161,7 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
           <Label>환경</Label>
           <div className="space-y-2">
             {environmentOptions.map((env) => (
-              <div key={env} className="flex items-center space-x-2">
+              <div key={env} className="flex items-center space-x-2 w-full">
                 <Checkbox
                   id={`env-${env}`}
                   checked={selectedEnvironment.includes(env)}
@@ -172,7 +172,7 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
                 />
                 <label
                   htmlFor={`env-${env}`}
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1"
                 >
                   {env}
                 </label>
@@ -188,7 +188,7 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
           <Label>최고 계절</Label>
           <div className="grid grid-cols-2 gap-2">
             {seasonOptions.map((season) => (
-              <div key={season} className="flex items-center space-x-2">
+              <div key={season} className="flex items-center space-x-2 w-full">
                 <Checkbox
                   id={`season-${season}`}
                   checked={selectedSeasons.includes(season)}
@@ -199,7 +199,7 @@ export function FilterSidebar({ onFilterChange }: FilterSidebarProps) {
                 />
                 <label
                   htmlFor={`season-${season}`}
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1"
                 >
                   {season}
                 </label>


### PR DESCRIPTION
## Summary
- 홈페이지의 예산, 지역, 환경, 계절 필터 옵션들이 각각 사용 가능한 최대 너비를 차지하도록 스타일 개선
- 모든 필터 옵션 컨테이너에 `w-full` 클래스 추가
- 모든 Label 요소에 `flex-1` 클래스 추가하여 남은 공간을 최대한 활용

## Changes
- **예산 필터**: RadioGroup 옵션들이 전체 너비 차지
- **지역 필터**: Checkbox 옵션들이 grid cell의 최대 너비 차지
- **환경 필터**: Checkbox 옵션들이 전체 너비 차지
- **계절 필터**: Checkbox 옵션들이 grid cell의 최대 너비 차지

## Test plan
- [ ] 데스크톱 화면에서 필터 옵션들이 균등하게 표시되는지 확인
- [ ] 모바일 Sheet에서도 동일하게 적용되는지 확인
- [ ] 필터 기능이 정상적으로 작동하는지 확인
- [ ] 다양한 화면 크기에서 레이아웃이 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)